### PR TITLE
Enable to describe erb syntax in config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ user_id: <Hatena user ID>
 blog_id: <Hatenablog ID>
 ```
 
+This file accepts ERB syntax.
+
+```yml
+consumer_key: <%= ENV['CONSUMER_KEY'] %>
+consumer_secret: <%= ENV['CONSUMER_SECRET'] %>
+access_token: <%= ENV['ACCESS_TOKEN'] %>
+access_token_secret: <%= ENV['ACCESS_TOKEN_SECRET'] %>
+user_id: <%= ENV['USER_ID'] %>
+blog_id: <%= ENV['BLOG_ID'] %>
+```
+
 ## Usage
 
 ```ruby

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'yaml'
 
 module Hatenablog
@@ -11,7 +12,7 @@ module Hatenablog
     # @param [String] config_file configuration file path
     # @return [Hatenablog::Configuration]
     def initialize(config_file)
-      config = YAML.load_file(config_file)
+      config = YAML.load(ERB.new(File.read(config_file)).result)
       unless config.has_key?('consumer_key') && config.has_key?('consumer_secret')     &&
              config.has_key?('access_token') && config.has_key?('access_token_secret') &&
              config.has_key?('user_id')      && config.has_key?('blog_id')

--- a/test/fixture/test_conf.yml
+++ b/test/fixture/test_conf.yml
@@ -1,6 +1,6 @@
 consumer_key: cMOVPffXo7LiL317UeaiEQ==
 consumer_secret: 0987654321ZYXWVUTSRQPONML=
-access_token: oGoYArVaBWpNSKp9ljXm+g==
-access_token_secret: 7OgCvJW/GPbFnAnIHgG2t1ivdzxrvZTdvJl/yA==
+access_token: <%= "oGoYArVaBWpNSKp9ljXm+g==" %>
+access_token_secret: <%= "7OgCvJW/GPbFnAnIHgG2t1ivdzxrvZTdvJl/yA==" %>
 user_id: test_user
 blog_id: test-user.hatenablog.com


### PR DESCRIPTION
This pull-request is for enabling to describe erb syntax in config.yml.
I would like to describe like `access_token: ENV['ACCESS_TOKEN']` in config.yml to include public repository.