### PR TITLE
Support Basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test Coverage](https://codeclimate.com/github/kymmt90/hatenablog/badges/coverage.svg)](https://codeclimate.com/github/kymmt90/hatenablog/coverage)
 
 A library for Hatenablog AtomPub API.
-This gem supports following operations using OAuth authorization:
+This gem supports following operations using OAuth or Basic authorization:
 
 - Get blog feeds, entries and categories
 - Post blog entries
@@ -70,12 +70,23 @@ user_id: <%= ENV['USER_ID'] %>
 blog_id: <%= ENV['BLOG_ID'] %>
 ```
 
+### (OPTIONAL) Get Basic Authentication credentials
+If you want to use Basic Authentication, visit `http://blog.hatena.ne.jp/#{user_id}/#{blog_id}/config/detail`
+and check your API key (APIキー) and set up `config.yml` like the following.
+
+```yml
+auth_type: basic
+api_key: <%= ENV['API_KEY'] %>
+user_id: <%= ENV['USER_ID'] %>
+blog_id: <%= ENV['BLOG_ID'] %>
+```
+
 ## Usage
 
 ```ruby
 require 'hatenablog'
 
-# Read the OAuth configuration from 'config.yml'
+# Read the configuration from 'config.yml'
 Hatenablog::Client.create do |blog|
   # Get each entry's content
   blog.entries.each do |entry|

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -20,7 +20,7 @@ module Hatenablog
     # @param [String] config_file configuration file path
     # @return [Hatenablog::Client] created hatenablog client
     def self.create(config_file = DEFAULT_CONFIG_PATH)
-      config = Configuration.new(config_file)
+      config = Configuration.create(config_file)
       blog = Hatenablog::Client.new(config)
       return blog unless block_given?
       yield blog

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -21,9 +21,7 @@ module Hatenablog
     # @return [Hatenablog::Client] created hatenablog client
     def self.create(config_file = DEFAULT_CONFIG_PATH)
       config = Configuration.new(config_file)
-      blog = Hatenablog::Client.new(config.consumer_key, config.consumer_secret,
-                                    config.access_token, config.access_token_secret,
-                                    config.user_id, config.blog_id)
+      blog = Hatenablog::Client.new(config)
       return blog unless block_given?
       yield blog
     end
@@ -173,15 +171,14 @@ module Hatenablog
 
     private
 
-    def initialize(consumer_key, consumer_secret, access_token, access_token_secret,
-                   user_id, blog_id)
-      consumer = OAuth::Consumer.new(consumer_key, consumer_secret)
+    def initialize(config)
+      consumer = OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
       @requester = Requester::OAuth.new(OAuth::AccessToken.new(consumer,
-                                                                  access_token,
-                                                                  access_token_secret))
+                                                               config.access_token,
+                                                               config.access_token_secret))
 
-      @user_id = user_id
-      @blog_id = blog_id
+      @user_id = config.user_id
+      @blog_id = config.blog_id
     end
 
 

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -4,6 +4,7 @@ require 'hatenablog/category'
 require 'hatenablog/entry'
 require 'hatenablog/feed'
 require 'hatenablog/configuration'
+require 'hatenablog/requester'
 
 module Hatenablog
   class Client
@@ -13,7 +14,7 @@ module Hatenablog
     MEMBER_URI     = "https://blog.hatena.ne.jp/%s/%s/atom/entry/%s".freeze
     CATEGORY_URI   = "https://blog.hatena.ne.jp/%s/%s/atom/category".freeze
 
-    attr_writer :access_token
+    attr_writer :requester
 
     # Create a new hatenablog AtomPub client from a configuration file.
     # @param [String] config_file configuration file path
@@ -175,7 +176,7 @@ module Hatenablog
     def initialize(consumer_key, consumer_secret, access_token, access_token_secret,
                    user_id, blog_id)
       consumer = OAuth::Consumer.new(consumer_key, consumer_secret)
-      @access_token = OAuthAccessToken.new(OAuth::AccessToken.new(consumer,
+      @requester = Requester::OAuth.new(OAuth::AccessToken.new(consumer,
                                                                   access_token,
                                                                   access_token_secret))
 
@@ -185,7 +186,7 @@ module Hatenablog
 
 
     def get(uri)
-      @access_token.get(uri)
+      @requester.get(uri)
     end
 
     def get_collection(uri = collection_uri)
@@ -200,84 +201,15 @@ module Hatenablog
     end
 
     def post(entry_xml, uri = collection_uri)
-      @access_token.post(uri, entry_xml)
+      @requester.post(uri, entry_xml)
     end
 
     def put(entry_xml, uri)
-      @access_token.put(uri, entry_xml)
+      @requester.put(uri, entry_xml)
     end
 
     def delete(uri)
-      @access_token.delete(uri)
+      @requester.delete(uri)
     end
   end
-
-  class OAuthAccessToken
-
-    # Create a new OAuth 1.0a access token.
-    # @param [OAuth::AccessToken] access_token access token object
-    def initialize(access_token)
-      @access_token = access_token
-    end
-
-    # HTTP GET method
-    # @param [string] uri target URI
-    # @return [Net::HTTPResponse] HTTP response
-    def get(uri)
-      begin
-        response = @access_token.get(uri)
-      rescue => problem
-        raise OAuthError, 'Fail to GET: ' + problem.to_s
-      end
-      response
-    end
-
-    # HTTP POST method
-    # @param [string] uri target URI
-    # @param [string] body HTTP request body
-    # @param [string] headers HTTP request headers
-    # @return [Net::HTTPResponse] HTTP response
-    def post(uri,
-             body = '',
-             headers = { 'Content-Type' => 'application/atom+xml; type=entry' } )
-      begin
-        response = @access_token.post(uri, body, headers)
-      rescue => problem
-        raise OAuthError, 'Fail to POST: ' + problem.to_s
-      end
-      response
-    end
-
-    # HTTP PUT method
-    # @param [string] uri target URI
-    # @param [string] body HTTP request body
-    # @param [string] headers HTTP request headers
-    # @return [Net::HTTPResponse] HTTP response
-    def put(uri,
-            body = '',
-            headers = { 'Content-Type' => 'application/atom+xml; type=entry' } )
-      begin
-        response = @access_token.put(uri, body, headers)
-      rescue => problem
-        raise OAuthError, 'Fail to PUT: ' + problem.to_s
-      end
-      response
-    end
-
-    # HTTP DELETE method
-    # @param [string] uri target URI
-    # @param [string] headers HTTP request headers
-    # @return [Net::HTTPResponse] HTTP response
-    def delete(uri,
-               headers = { 'Content-Type' => 'application/atom+xml; type=entry' })
-      begin
-        response = @access_token.delete(uri, headers)
-      rescue => problem
-        raise OAuthError, 'Fail to DELETE: ' + problem.to_s
-      end
-      response
-    end
-  end
-
-  class OAuthError < StandardError; end
 end

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -1,5 +1,3 @@
-require 'oauth'
-
 require 'hatenablog/category'
 require 'hatenablog/entry'
 require 'hatenablog/feed'
@@ -172,19 +170,9 @@ module Hatenablog
     private
 
     def initialize(config)
-      @requester = create_requester(config)
-
+      @requester = Requester.create(config)
       @user_id = config.user_id
       @blog_id = config.blog_id
-    end
-
-    def create_requester(config)
-      if config.auth_type == 'basic'
-        Requester::Basic.new(config.user_id, config.api_key)
-      else
-        consumer = OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
-        Requester::OAuth.new(OAuth::AccessToken.new(consumer, config.access_token, config.access_token_secret))
-      end
     end
 
     def get(uri)

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -172,15 +172,20 @@ module Hatenablog
     private
 
     def initialize(config)
-      consumer = OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
-      @requester = Requester::OAuth.new(OAuth::AccessToken.new(consumer,
-                                                               config.access_token,
-                                                               config.access_token_secret))
+      @requester = create_requester(config)
 
       @user_id = config.user_id
       @blog_id = config.blog_id
     end
 
+    def create_requester(config)
+      if config.auth_type == 'basic'
+        Requester::Basic.new(config.user_id, config.api_key)
+      else
+        consumer = OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
+        Requester::OAuth.new(OAuth::AccessToken.new(consumer, config.access_token, config.access_token_secret))
+      end
+    end
 
     def get(uri)
       @requester.get(uri)

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -4,11 +4,13 @@ require 'ostruct'
 
 module Hatenablog
   class Configuration < OpenStruct
-    OAUTH_CONFIGS = %w(consumer_key consumer_secret access_token access_token_secret user_id blog_id)
+    OAUTH_KEYS = %w(consumer_key consumer_secret access_token access_token_secret user_id blog_id)
+    BASIC_KEYS = %w(api_key user_id blog_id)
 
     def self.create(config_file)
       config = YAML.load(ERB.new(File.read(config_file)).result)
-      unless (lacking_keys = OAUTH_CONFIGS.select {|key| !config.has_key? key}).empty?
+      keys = config['auth_type'] == 'basic' ? BASIC_KEYS : OAUTH_KEYS
+      unless (lacking_keys = keys.select {|key| !config.has_key? key}).empty?
         raise ConfigurationError, "Following keys are not setup. #{lacking_keys}"
       end
 

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -7,6 +7,9 @@ module Hatenablog
     OAUTH_KEYS = %w(consumer_key consumer_secret access_token access_token_secret user_id blog_id)
     BASIC_KEYS = %w(api_key user_id blog_id)
 
+    # Create a new configuration.
+    # @param [String] config_file configuration file path
+    # @return [Hatenablog::Configuration]
     def self.create(config_file)
       config = YAML.load(ERB.new(File.read(config_file)).result)
       keys = config['auth_type'] == 'basic' ? BASIC_KEYS : OAUTH_KEYS

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -1,30 +1,18 @@
 require 'erb'
 require 'yaml'
+require 'ostruct'
 
 module Hatenablog
-  class Configuration
-    # For OAuth authorization.
-    attr_reader :consumer_key, :consumer_secret, :access_token, :access_token_secret
+  class Configuration < OpenStruct
+    OAUTH_CONFIGS = %w(consumer_key consumer_secret access_token access_token_secret user_id blog_id)
 
-    attr_reader :user_id, :blog_id
-
-    # Create a new configuration.
-    # @param [String] config_file configuration file path
-    # @return [Hatenablog::Configuration]
-    def initialize(config_file)
+    def self.create(config_file)
       config = YAML.load(ERB.new(File.read(config_file)).result)
-      unless config.has_key?('consumer_key') && config.has_key?('consumer_secret')     &&
-             config.has_key?('access_token') && config.has_key?('access_token_secret') &&
-             config.has_key?('user_id')      && config.has_key?('blog_id')
-        raise ConfigurationError, 'the configure file is incorrect'
+      unless (lacking_keys = OAUTH_CONFIGS.select {|key| !config.has_key? key}).empty?
+        raise ConfigurationError, "Following keys are not setup. #{lacking_keys}"
       end
 
-      @consumer_key        = config['consumer_key']
-      @consumer_secret     = config['consumer_secret']
-      @access_token        = config['access_token']
-      @access_token_secret = config['access_token_secret']
-      @user_id             = config['user_id']
-      @blog_id             = config['blog_id']
+      new(config)
     end
   end
 

--- a/lib/hatenablog/requester.rb
+++ b/lib/hatenablog/requester.rb
@@ -1,8 +1,18 @@
 require 'net/http'
+require 'oauth'
 
 module Hatenablog
   module Requester
     class RequestError < StandardError; end
+
+    def self.create(config)
+      if config.auth_type == 'basic'
+        Requester::Basic.new(config.user_id, config.api_key)
+      else
+        consumer = ::OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
+        Requester::OAuth.new(::OAuth::AccessToken.new(consumer, config.access_token, config.access_token_secret))
+      end
+    end
 
     class OAuth
       # Create a new OAuth 1.0a access token.

--- a/lib/hatenablog/requester.rb
+++ b/lib/hatenablog/requester.rb
@@ -88,8 +88,9 @@ module Hatenablog
         delete: Net::HTTP::Delete
       }
 
-      # Create a new OAuth 1.0a access token.
-      # @param [OAuth::AccessToken] access_token access token object
+      # Create a new Basic authentication requester.
+      # @params [string] user_id Hatena user ID
+      # @params [string] api_key Hatena API key
       def initialize(user_id, api_key)
         @user_id = user_id
         @api_key = api_key

--- a/lib/hatenablog/requester.rb
+++ b/lib/hatenablog/requester.rb
@@ -1,0 +1,71 @@
+module Hatenablog
+  module Requester
+    class RequestError < StandardError; end
+
+    class OAuth
+      # Create a new OAuth 1.0a access token.
+      # @param [OAuth::AccessToken] access_token access token object
+      def initialize(access_token)
+        @access_token = access_token
+      end
+
+      # HTTP GET method
+      # @param [string] uri target URI
+      # @return [Net::HTTPResponse] HTTP response
+      def get(uri)
+        begin
+          response = @access_token.get(uri)
+        rescue => problem
+          raise RequestError, 'Fail to GET: ' + problem.to_s
+        end
+        response
+      end
+
+      # HTTP POST method
+      # @param [string] uri target URI
+      # @param [string] body HTTP request body
+      # @param [string] headers HTTP request headers
+      # @return [Net::HTTPResponse] HTTP response
+      def post(uri,
+               body = '',
+               headers = { 'Content-Type' => 'application/atom+xml; type=entry' } )
+        begin
+          response = @access_token.post(uri, body, headers)
+        rescue => problem
+          raise RequestError, 'Fail to POST: ' + problem.to_s
+        end
+        response
+      end
+
+      # HTTP PUT method
+      # @param [string] uri target URI
+      # @param [string] body HTTP request body
+      # @param [string] headers HTTP request headers
+      # @return [Net::HTTPResponse] HTTP response
+      def put(uri,
+              body = '',
+              headers = { 'Content-Type' => 'application/atom+xml; type=entry' } )
+        begin
+          response = @access_token.put(uri, body, headers)
+        rescue => problem
+          raise RequestError, 'Fail to PUT: ' + problem.to_s
+        end
+        response
+      end
+
+      # HTTP DELETE method
+      # @param [string] uri target URI
+      # @param [string] headers HTTP request headers
+      # @return [Net::HTTPResponse] HTTP response
+      def delete(uri,
+                 headers = { 'Content-Type' => 'application/atom+xml; type=entry' })
+        begin
+          response = @access_token.delete(uri, headers)
+        rescue => problem
+          raise RequestError, 'Fail to DELETE: ' + problem.to_s
+        end
+        response
+      end
+    end
+  end
+end

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -203,52 +203,6 @@ module Hatenablog
       end
     end
 
-    sub_test_case 'OAuth error' do
-      setup do
-        setup_errors
-      end
-
-      test 'fail get' do
-        assert_raise(Hatenablog::Requester::RequestError.new("Fail to GET: problem")) do
-          @sut.get('http://www.example.com')
-        end
-      end
-
-      test 'fail post' do
-        assert_raise(Hatenablog::Requester::RequestError.new("Fail to POST: problem")) do
-          @sut.post('http://www.example.com')
-        end
-      end
-
-      test 'fail put' do
-        assert_raise(Hatenablog::Requester::RequestError.new("Fail to PUT: problem")) do
-          @sut.put('http://www.example.com')
-        end
-      end
-
-      test 'fail delete' do
-        assert_raise(Hatenablog::Requester::RequestError.new("Fail to DELETE: problem")) do
-          @sut.delete('http://www.example.com')
-        end
-      end
-
-      def setup_errors
-        headers = { 'Content-Type' => 'application/atom+xml; type=entry' }
-
-        access_token = Object.new
-        stub(access_token).get('http://www.example.com')    { raise 'problem' }
-        stub(access_token).post('http://www.example.com',
-                                '',
-                                headers)                     { raise 'problem' }
-        stub(access_token).put('http://www.example.com',
-                               '',
-                               headers)                      { raise 'problem' }
-        stub(access_token).delete('http://www.example.com',
-                                  headers)                  { raise 'problem' }
-        @sut = Hatenablog::Requester::OAuth.new(access_token)
-      end
-    end
-
     sub_test_case 'helper methods' do
       setup do
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -28,12 +28,12 @@ module Hatenablog
 
       def setup_feed
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
-        access_token = Object.new
+        requester = Object.new
         response = Object.new
         f = File.open('test/fixture/feed_1.xml')
         stub(response).body { f.read }
-        stub(access_token).get { response }
-        @sut.access_token = access_token
+        stub(requester).get { response }
+        @sut.requester = requester
       end
     end
 
@@ -70,7 +70,7 @@ module Hatenablog
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
         response1    = Object.new
         response2    = Object.new
-        access_token = Object.new
+        requester = Object.new
         feed1        = File.open('test/fixture/feed_1.xml').read
         feed2        = File.open('test/fixture/feed_2.xml').read
         @sut_feed1   = Feed.load_xml(feed1)
@@ -78,9 +78,9 @@ module Hatenablog
 
         stub(response1).body { feed1 }
         stub(response2).body { feed2 }
-        stub(access_token).get(@sut.collection_uri) { response1 }
-        stub(access_token).get('https://blog.hatena.ne.jp/test_user/test-user.hatenablog.com/atom/entry?page=1377584217') { response2 }
-        @sut.access_token = access_token
+        stub(requester).get(@sut.collection_uri) { response1 }
+        stub(requester).get('https://blog.hatena.ne.jp/test_user/test-user.hatenablog.com/atom/entry?page=1377584217') { response2 }
+        @sut.requester = requester
       end
     end
 
@@ -116,12 +116,12 @@ module Hatenablog
 
       def setup_entry
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
-        access_token = Object.new
+        requester = Object.new
         response = Object.new
         f = File.open('test/fixture/entry.xml')
         stub(response).body { f.read }
-        stub(access_token).get { response }
-        @sut.access_token = access_token
+        stub(requester).get { response }
+        @sut.requester = requester
       end
     end
 
@@ -137,11 +137,11 @@ module Hatenablog
       def setup_post_entry_mock
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
         response     = Object.new
-        access_token = Object.new
+        requester = Object.new
         f = File.open('test/fixture/entry.xml')
         mock(response).body { f.read }
-        mock(access_token).post(@sut.collection_uri, @sut.entry_xml) { response }
-        @sut.access_token = access_token
+        mock(requester).post(@sut.collection_uri, @sut.entry_xml) { response }
+        @sut.requester = requester
       end
     end
 
@@ -157,11 +157,11 @@ module Hatenablog
       def setup_update_entry_mock
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
         response     = Object.new
-        access_token = Object.new
+        requester = Object.new
         f = File.open('test/fixture/entry.xml')
         mock(response).body { f.read }
-        mock(access_token).put(@sut.member_uri('6653458415122161047'), @sut.entry_xml) { response }
-        @sut.access_token = access_token
+        mock(requester).put(@sut.member_uri('6653458415122161047'), @sut.entry_xml) { response }
+        @sut.requester = requester
       end
     end
 
@@ -176,9 +176,9 @@ module Hatenablog
 
       def setup_delete_entry_mock
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
-        access_token = Object.new
-        mock(access_token).delete(@sut.member_uri('6653458415122161047'))
-        @sut.access_token = access_token
+        requester = Object.new
+        mock(requester).delete(@sut.member_uri('6653458415122161047'))
+        @sut.requester = requester
       end
     end
 
@@ -194,12 +194,12 @@ module Hatenablog
 
       def setup_categories
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
-        access_token = Object.new
+        requester = Object.new
         response = Object.new
         f = File.open('test/fixture/categories_1.xml')
         stub(response).body { f.read }
-        stub(access_token).get { response }
-        @sut.access_token = access_token
+        stub(requester).get { response }
+        @sut.requester = requester
       end
     end
 
@@ -209,25 +209,25 @@ module Hatenablog
       end
 
       test 'fail get' do
-        assert_raise(OAuthError.new("Fail to GET: problem")) do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to GET: problem")) do
           @sut.get('http://www.example.com')
         end
       end
 
       test 'fail post' do
-        assert_raise(OAuthError.new("Fail to POST: problem")) do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to POST: problem")) do
           @sut.post('http://www.example.com')
         end
       end
 
       test 'fail put' do
-        assert_raise(OAuthError.new("Fail to PUT: problem")) do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to PUT: problem")) do
           @sut.put('http://www.example.com')
         end
       end
 
       test 'fail delete' do
-        assert_raise(OAuthError.new("Fail to DELETE: problem")) do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to DELETE: problem")) do
           @sut.delete('http://www.example.com')
         end
       end
@@ -245,7 +245,7 @@ module Hatenablog
                                headers)                      { raise 'problem' }
         stub(access_token).delete('http://www.example.com',
                                   headers)                  { raise 'problem' }
-        @sut = OAuthAccessToken.new(access_token)
+        @sut = Hatenablog::Requester::OAuth.new(access_token)
       end
     end
 

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -68,13 +68,13 @@ module Hatenablog
 
       def setup_feeds
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
-        response1    = Object.new
-        response2    = Object.new
-        requester = Object.new
-        feed1        = File.open('test/fixture/feed_1.xml').read
-        feed2        = File.open('test/fixture/feed_2.xml').read
-        @sut_feed1   = Feed.load_xml(feed1)
-        @sut_feed2   = Feed.load_xml(feed2)
+        response1  = Object.new
+        response2  = Object.new
+        requester  = Object.new
+        feed1      = File.open('test/fixture/feed_1.xml').read
+        feed2      = File.open('test/fixture/feed_2.xml').read
+        @sut_feed1 = Feed.load_xml(feed1)
+        @sut_feed2 = Feed.load_xml(feed2)
 
         stub(response1).body { feed1 }
         stub(response2).body { feed2 }

--- a/test/hatenablog/configuration_test.rb
+++ b/test/hatenablog/configuration_test.rb
@@ -6,7 +6,7 @@ module Hatenablog
   class ConfigurationTest < Test::Unit::TestCase
     sub_test_case 'correct configuration' do
       setup do
-        @sut = Hatenablog::Configuration.new('test/fixture/test_conf.yml')
+        @sut = Hatenablog::Configuration.create('test/fixture/test_conf.yml')
       end
 
       test 'consumer key' do
@@ -36,8 +36,8 @@ module Hatenablog
 
     sub_test_case 'incorrect configuration' do
       test 'raise error when reading incorrect configuration' do
-        assert_raise(Hatenablog::ConfigurationError.new('the configure file is incorrect')) do
-          Hatenablog::Configuration.new('test/fixture/error_conf.yml')
+        assert_raise(Hatenablog::ConfigurationError.new('Following keys are not setup. ["access_token"]')) do
+          Hatenablog::Configuration.create('test/fixture/error_conf.yml')
         end
       end
     end

--- a/test/hatenablog/requester_test.rb
+++ b/test/hatenablog/requester_test.rb
@@ -48,5 +48,69 @@ module Hatenablog
         @sut = Hatenablog::Requester::OAuth.new(access_token)
       end
     end
+
+    sub_test_case 'Basic' do
+      BASIC = Hatenablog::Requester::Basic
+      URL = 'http://www.example.com'
+
+      test 'get' do
+        setup_basic_auth
+        req = @sut.get(URL)
+        assert_equal 'GET', req.method
+        assert_equal 'Basic dGVzdF91c2VyOnN1a3c5ZTg3Zmc=', req['authorization']
+      end
+
+      test 'post' do
+        setup_basic_auth
+        req = @sut.post(URL, 'body', {'Foo' => 'bar'})
+        assert_equal 'POST', req.method
+        assert_equal 'Basic dGVzdF91c2VyOnN1a3c5ZTg3Zmc=', req['authorization']
+        assert_equal 'body', req.body
+        assert_equal 'bar', req['Foo']
+      end
+
+      test 'put' do
+        setup_basic_auth
+        req = @sut.put(URL, 'body', {'Foo' => 'bar'})
+        assert_equal 'PUT', req.method
+        assert_equal 'Basic dGVzdF91c2VyOnN1a3c5ZTg3Zmc=', req['authorization']
+        assert_equal 'body', req.body
+        assert_equal 'bar', req['Foo']
+      end
+
+      test 'delete' do
+        setup_basic_auth
+        req = @sut.delete(URL, {'Foo' => 'bar'})
+        assert_equal 'DELETE', req.method
+        assert_equal 'Basic dGVzdF91c2VyOnN1a3c5ZTg3Zmc=', req['authorization']
+        assert_equal 'bar', req['Foo']
+      end
+
+      test 'raise error' do
+        setup_basic_auth(error: true)
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to GET: problem")) do
+          @sut.get('http://www.example.com')
+        end
+      end
+
+      def setup_basic_auth(error: false)
+        user_id = 'test_user'
+        api_key = 'sukw9e87fg'
+        @sut = BASIC.new(user_id, api_key)
+
+        stub(Net::HTTP).start do
+          http = Object.new
+          # return Request object or Error
+          stub(http).request do |req|
+            if error
+              raise 'problem'
+            else
+              req
+            end
+          end
+        end
+      end
+
+    end
   end
 end

--- a/test/hatenablog/requester_test.rb
+++ b/test/hatenablog/requester_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+require 'test/unit/rr'
+
+module Hatenablog
+  class RequesterTest < Test::Unit::TestCase
+    sub_test_case 'OAuth error' do
+      setup do
+        setup_errors
+      end
+
+      test 'fail get' do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to GET: problem")) do
+          @sut.get('http://www.example.com')
+        end
+      end
+
+      test 'fail post' do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to POST: problem")) do
+          @sut.post('http://www.example.com')
+        end
+      end
+
+      test 'fail put' do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to PUT: problem")) do
+          @sut.put('http://www.example.com')
+        end
+      end
+
+      test 'fail delete' do
+        assert_raise(Hatenablog::Requester::RequestError.new("Fail to DELETE: problem")) do
+          @sut.delete('http://www.example.com')
+        end
+      end
+
+      def setup_errors
+        headers = { 'Content-Type' => 'application/atom+xml; type=entry' }
+
+        access_token = Object.new
+        stub(access_token).get('http://www.example.com')    { raise 'problem' }
+        stub(access_token).post('http://www.example.com',
+                                '',
+                                headers)                     { raise 'problem' }
+        stub(access_token).put('http://www.example.com',
+                               '',
+                               headers)                      { raise 'problem' }
+        stub(access_token).delete('http://www.example.com',
+                                  headers)                  { raise 'problem' }
+        @sut = Hatenablog::Requester::OAuth.new(access_token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi, thank you for sharing the library.
I'd like to use Hatena Blog API via Basic authentication.

ref http://developer.hatena.ne.jp/ja/documents/blog/apis/atom
> Basic認証についてはユーザ名としてはてなIDを、パスワードとしてAPIキーを利用することで認証できます。Basic認証はAPIのURLがhttpsではじまる場合にのみ利用できます。

To do so, I made web requesting encapsulated as `requester` and implemented a requester for Basic auth. Could you review it? Thank you.