### PR TITLE
Configure Client with a block

### DIFF
--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -24,6 +24,16 @@ module Hatenablog
       yield blog
     end
 
+    def initialize(config = nil)
+      if block_given?
+        yield config = Configuration.new
+        config.check_valid_or_raise
+      end
+      @requester = Requester.create(config)
+      @user_id = config.user_id
+      @blog_id = config.blog_id
+    end
+
     # Get a blog title.
     # @return [String] blog title
     def title
@@ -164,14 +174,7 @@ module Hatenablog
       builder.to_xml
     end
 
-
     private
-
-    def initialize(config)
-      @requester = Requester.create(config)
-      @user_id = config.user_id
-      @blog_id = config.blog_id
-    end
 
     def get(uri)
       @requester.get(uri)

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -17,11 +17,13 @@ module Hatenablog
     end
 
     def check_valid_or_raise
-      unless (lacking_keys = self.lacking_keys).empty?
+      unless (lacking_keys = self.send(:lacking_keys)).empty?
         raise ConfigurationError, "Following keys are not setup. #{lacking_keys.map(&:to_s)}"
       end
       self
     end
+
+    private
 
     def lacking_keys
       required_keys = self['auth_type'] == 'basic' ? BASIC_KEYS : OAUTH_KEYS

--- a/lib/hatenablog/configuration.rb
+++ b/lib/hatenablog/configuration.rb
@@ -13,10 +13,14 @@ module Hatenablog
     def self.create(config_file)
       loaded_config = YAML.load(ERB.new(File.read(config_file)).result)
       config = new(loaded_config)
-      unless (lacking_keys = config.lacking_keys).empty?
+      config.check_valid_or_raise
+    end
+
+    def check_valid_or_raise
+      unless (lacking_keys = self.lacking_keys).empty?
         raise ConfigurationError, "Following keys are not setup. #{lacking_keys.map(&:to_s)}"
       end
-      config
+      self
     end
 
     def lacking_keys

--- a/test/fixture/test_conf_basic.yml
+++ b/test/fixture/test_conf_basic.yml
@@ -1,0 +1,4 @@
+api_key: sukw9e87fg
+user_id: test_user
+blog_id: test-user.hatenablog.com
+auth_type: basic

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -5,6 +5,58 @@ require 'hatenablog/client'
 
 module Hatenablog
   class ClientTest < Test::Unit::TestCase
+    sub_test_case 'initialize client with block' do
+      setup do
+        setup_feed
+      end
+
+      test 'get the blog title' do
+        assert_equal 'Test Blog', @sut.title
+      end
+
+      test 'get the blog author name' do
+        assert_equal 'test_user', @sut.author_name
+      end
+
+      test 'the entries size is 1' do
+        assert_equal 1, @sut.entries.length
+      end
+
+      test 'get the entry' do
+        assert_equal "2500000000", @sut.entries[0].id
+      end
+
+      def setup_feed
+        @sut = Hatenablog::Client.new do |config|
+          config.consumer_key = 'cMOVPffXo7LiL317UeaiEQ=='
+          config.consumer_secret = '0987654321ZYXWVUTSRQPONML='
+          config.access_token = 'oGoYArVaBWpNSKp9ljXm+g=='
+          config.access_token_secret = '7OgCvJW/GPbFnAnIHgG2t1ivdzxrvZTdvJl/yA=='
+          config.user_id = 'test_user'
+          config.blog_id = 'test-user.hatenablog.com'
+        end
+        requester = Object.new
+        response = Object.new
+        f = File.open('test/fixture/feed_1.xml')
+        stub(response).body { f.read }
+        stub(requester).get { response }
+        @sut.requester = requester
+      end
+    end
+
+    sub_test_case 'fail to initialize client with block' do
+      test 'fail to initialize client' do
+        assert_raise Hatenablog::ConfigurationError, 'Following keys are not setup. ["access_token", "access_token_secret"]' do
+          @sut = Hatenablog::Client.new do |config|
+            config.consumer_key = 'cMOVPffXo7LiL317UeaiEQ=='
+            config.consumer_secret = '0987654321ZYXWVUTSRQPONML='
+            config.user_id = 'test_user'
+            config.blog_id = 'test-user.hatenablog.com'
+          end
+        end
+      end
+    end
+
     sub_test_case 'get the single page feed' do
       setup do
         setup_feed

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -19,11 +19,11 @@ module Hatenablog
       end
 
       test 'the entries size is 1' do
-        assert_equal 1, @sut.entries.length
+        assert_equal 1, @sut.entries.to_a.length
       end
 
       test 'get the entry' do
-        assert_equal "2500000000", @sut.entries[0].id
+        assert_equal "2500000000", @sut.entries.to_a[0].id
       end
 
       def setup_feed

--- a/test/hatenablog/configuration_test.rb
+++ b/test/hatenablog/configuration_test.rb
@@ -4,7 +4,7 @@ require 'hatenablog/configuration'
 
 module Hatenablog
   class ConfigurationTest < Test::Unit::TestCase
-    sub_test_case 'correct configuration' do
+    sub_test_case 'correct configuration with OAuth configuration file' do
       setup do
         @sut = Hatenablog::Configuration.create('test/fixture/test_conf.yml')
       end
@@ -31,6 +31,36 @@ module Hatenablog
 
       test 'blog ID' do
         assert_equal 'test-user.hatenablog.com', @sut.blog_id
+      end
+
+      test 'valid configuration' do
+        assert_equal @sut, @sut.check_valid_or_raise
+      end
+    end
+
+    sub_test_case 'correct configuration with Basic configuration file' do
+      setup do
+        @sut = Hatenablog::Configuration.create('test/fixture/test_conf_basic.yml')
+      end
+
+      test 'API key' do
+        assert_equal 'sukw9e87fg', @sut.api_key
+      end
+
+      test 'user ID' do
+        assert_equal 'test_user', @sut.user_id
+      end
+
+      test 'blog ID' do
+        assert_equal 'test-user.hatenablog.com', @sut.blog_id
+      end
+
+      test 'auth type' do
+        assert_equal 'basic', @sut.auth_type
+      end
+
+      test 'valid configuration' do
+        assert_equal @sut, @sut.check_valid_or_raise
       end
     end
 


### PR DESCRIPTION
```ruby
# configure the blog client in a block
blog = Hatenablog::Client.new do |config|
  config.consumer_token = ENV['HATENA_CONSUMRE_TOKEN']
  config.consumer_secret = ENV['HATENA_CONSUMER_SECRET']
  config.access_token = ENV['HATENA_ACCESS_TOKEN']
  config.access_secret = ENV['HATENA_ACCESS_SECRET']
  config.blog_id = ENV['HATENABLOG_ID']
  config.user_id = ENV['HATENA_USER_ID']
  config.auth = ENV['HATENABLOG_AUTH']
  config.api_key = ENV['HATENA_API_KEY']
end
blog.post_entry(...)
```