### PR TITLE
Add authorize_url param to get_access_token

### DIFF
--- a/exe/get_access_token
+++ b/exe/get_access_token
@@ -10,6 +10,7 @@ class AccessTokenGetter
   SITE_URI = 'https://www.hatena.com'
   REQUEST_TOKEN_URI = '/oauth/initiate?scope=read_public%2Cread_private%2Cwrite_public%2Cwrite_private'
   ACCESS_TOKEN_URI = '/oauth/token'
+  AUTHORIZE_URI = 'https://www.hatena.ne.jp/oauth/authorize'
 
   def initialize(consumer_key, consumer_secret)
     @consumer_key    = consumer_key
@@ -19,7 +20,8 @@ class AccessTokenGetter
                                     oauth_callback: 'oob',
                                     site: SITE_URI,
                                     request_token_url: REQUEST_TOKEN_URI,
-                                    access_token_url: ACCESS_TOKEN_URI)
+                                    access_token_url: ACCESS_TOKEN_URI,
+                                    authorize_url: AUTHORIZE_URI)
   end
 
   def get_request_token


### PR DESCRIPTION
Hi, This gem was a great helpful for me.

I found a bug, and sent pull request.
Though you might be so busy, if you have some time, please check this PR.

---

I've added `authorize_url` to params, becase `https://www.hatena.com/oauth/authorize` that generated after executing `get_access_token <consumer_key> <consumer_secret>` is wrong endpoint.

## OAuth Endpoints

| Type | URL |
|:---|:---|
| Temporary Credential Request URL | https://www.hatena.com/oauth/initiate |
| Resource Owner Authorization URL (PC) | https://www.hatena.ne.jp/oauth/authorize |
| Token Request URL | https://www.hatena.com/oauth/token |