### PR TITLE
Bump Ruby versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 env:
   - TZ=Asia/Tokyo
 addons:


### PR DESCRIPTION
No longer support end-of-life Ruby 2.2.10