### PR TITLE
Suppress warnings

### DIFF
--- a/lib/hatenablog/entry.rb
+++ b/lib/hatenablog/entry.rb
@@ -19,6 +19,7 @@ module Hatenablog
         define_method(method) do |*args, &block|
           result = send(origin_method, *args, &block)
           send(hook)
+          result
         end
       end
     end
@@ -27,8 +28,9 @@ module Hatenablog
   class Entry
     extend AfterHook
 
-    attr_accessor :uri, :author_name, :title, :content, :draft, :categories
+    attr_accessor :uri, :author_name, :title, :content, :draft
     attr_reader   :edit_uri, :id, :updated
+    attr_writer :categories
 
     def updated=(date)
       @updated = Time.parse(date)
@@ -130,8 +132,10 @@ module Hatenablog
       @content     = @document.at_css('content').content
       @draft       = @document.at_css('entry app|control app|draft').content
       @categories  = parse_categories
-      unless @document.at_css('entry updated').nil?
+      if @document.at_css('entry updated')
         @updated = Time.parse(@document.at_css('entry updated').content)
+      else
+        @updated = nil
       end
     end
 


### PR DESCRIPTION
This pull request suppresses three kinds of warnings. 


First, it suppresses not initialized instance variable warning.

We can see the warning while the test.

example:

```
/home/pocke/ghq/github.com/kymmt90/hatenablog/lib/hatenablog/entry.rb:153: warning: instance variable @updated not initialized
```


I added `@updated = nil` assignment to suppress the warning.


Second, it is "assigned but unused variable - result".
It means `result` was ignored.
I guess it should be the returned value of the dynamic method.
So I added `result` to return it.

Last, it is "method redefined; discarding old categories".
It means `categories` was redefined.
The first "categories" was defined by `attr_accessor` method. But it was overridden by `def categories`. So I removed `:categories` from `attr_accessor`, and add `attr_writer`.

---

The last two warnings are available with just requiring the gem.

```bash
$ ruby -Ilib -rhatenablog -e '' 
/home/pocke/ghq/github.com/kymmt90/hatenablog/lib/hatenablog/entry.rb:20: warning: assigned but unused variable - result
/home/pocke/ghq/github.com/kymmt90/hatenablog/lib/hatenablog/entry.rb:75: warning: method redefined; discarding old categories
```


---

Thank you for the great product! 