### PR TITLE
Make each without block return an Enumerator

### DIFF
--- a/lib/hatenablog/category.rb
+++ b/lib/hatenablog/category.rb
@@ -15,9 +15,11 @@ module Hatenablog
       @categories.dup
     end
 
-    def each
+    def each(&block)
+      return enum_for(__method__) unless block_given?
+
       @categories.each do |category|
-        yield category
+        block.call(category)
       end
     end
 

--- a/lib/hatenablog/client.rb
+++ b/lib/hatenablog/client.rb
@@ -212,10 +212,12 @@ module Hatenablog
       @page = page
     end
 
-    def each
+    def each(&block)
+      return enum_for(__method__) unless block_given?
+
       current_page = 0
       until (@page && current_page > @page) || !(feed = @client.next_feed(feed))
-        feed.entries.each { |entry| yield entry }
+        feed.entries.each { |entry| block.call(entry) }
         current_page += 1
       end
     end


### PR DESCRIPTION

I got a LocalJumpError with no-block `Entries#each`.

```ruby
client.entries.each # => LocalJumpError
```

But sometimes we want to call `each` without a block.
I guess the most popular case is `each.with_index`.

So I think it is useful if `each` without block returns an Enumerable.
This pull request enables to work it.


`return enum_for(__method__) unless block_given?` is a popular idiom to return an Enumerator.