### PR TITLE
Add formatted_content method to Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,13 @@ entry.id
 entry.uri
 entry.edit_uri
 entry.author_name
-entry.title       #=> 'Example Title'
-entry.content     #=> 'This is the **example** entry.'
-entry.draft       #=> 'yes'
-entry.draft?      #=> true
-entry.categories  #=> ['Ruby', 'Rails']
-entry.updated     # Updated datetime
+entry.title             #=> 'Example Title'
+entry.content           #=> 'This is the **example** entry.'
+entry.formatted_content #=> '<p>This is the <strong>example</strong> entry.</p>'
+entry.draft             #=> 'yes'
+entry.draft?            #=> true
+entry.categories        #=> ['Ruby', 'Rails']
+entry.updated           # Updated datetime
 
 client.update_entry(
   entry.id,

--- a/lib/hatenablog/entry.rb
+++ b/lib/hatenablog/entry.rb
@@ -89,6 +89,11 @@ module Hatenablog
       @document.to_s.gsub(/\"/, "'")
     end
 
+    # @return [String]
+    def formatted_content
+      @formatted_content
+    end
+
     def self.build_xml(uri, edit_uri, author_name, title, content, draft, categories, updated)
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
         xml.entry('xmlns'     => 'http://www.w3.org/2005/Atom',
@@ -130,6 +135,8 @@ module Hatenablog
       @author_name = @document.at_css('author name').content
       @title       = @document.at_css('title').content
       @content     = @document.at_css('content').content
+      @formatted_content = @document.xpath('//hatena:formatted-content', hatena: 'http://www.hatena.ne.jp/info/xmlns#')[0]
+      @formatted_content = @formatted_content.content if @formatted_content
       @draft       = @document.at_css('entry app|control app|draft').content
       @categories  = parse_categories
       if @document.at_css('entry updated')

--- a/test/hatenablog/client_test.rb
+++ b/test/hatenablog/client_test.rb
@@ -176,6 +176,10 @@ module Hatenablog
         assert_false @got_entry.draft?
       end
 
+      test 'get the formatted content' do
+        assert_equal "<p>This is the test entry.</p>\n  ", @got_entry.formatted_content
+      end
+
       def setup_entry
         @sut = Hatenablog::Client.create('test/fixture/test_conf.yml')
         requester = Object.new


### PR DESCRIPTION
This pull-request provides updates on `Hatenablog::Entry` to allow developers to fetch content formatted by Hatena Blog.