### PR TITLE
Display warnings when executing tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = Dir["test/hatenablog/*_test.rb"]
   t.verbose = true
+  t.warning = true
 end
 
 YARD::Rake::YardocTask.new do |t|


### PR DESCRIPTION
Use `Rake::TestTask#warning=` explicitly.

cf. https://ruby-doc.org/stdlib-3.0.2/libdoc/rake/rdoc/Rake/TestTask.html